### PR TITLE
deqp: limit memory used to store and process deqp results

### DIFF
--- a/build_support/deqp_builder.py
+++ b/build_support/deqp_builder.py
@@ -253,9 +253,6 @@ class DeqpTrie:
                         # text content can be None
                         if a_text.text:
                             out_txt += a_text.text + "\n"
-                        if len(out_txt > 1000):
-                            out_txt += "WARN: verbose output limited to save memory."
-                            break
                     self._stdout[test] = out_txt
                 # get the test duration value
                 for number in t.findall("./Number"):


### PR DESCRIPTION
Overall use for vulkancts climbs to 4G and crashes machines.  The call
to wflinfo for the mesa version was misplaced, and should have taken
place before any tests were run.

The stdout text size turned out not to be the critical issue, and
broke result parsing for some tests.