### PR TITLE
Use 'flat' git repo caching

### DIFF
--- a/build_support/repo_set.py
+++ b/build_support/repo_set.py
@@ -1,4 +1,4 @@
-# Copyright (C) Intel Corp.  2014.  All Rights Reserved.
+# Copyright (C) Intel Corp.  2018.  All Rights Reserved.
 
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -23,6 +23,7 @@
 #  **********************************************************************/
 #  * Authors:
 #  *   Mark Janes <mark.a.janes@intel.com>
+#  *   Clayton Craft <clayton.a.craft@intel.com>
 #  **********************************************************************/
 
 import hashlib
@@ -41,6 +42,7 @@ from . import ProjectMap
 from . import Options
 from . import run_batch_command
 
+
 class _ProjectBranch:
     def __init__(self, projectName):
         # default to master branch
@@ -48,6 +50,7 @@ class _ProjectBranch:
         self.name = projectName
         self.sha = None
         self.trigger = False
+
 
 class BranchSpecification:
     """This class tracks a "branch set" in the build's git repositories
@@ -110,7 +113,7 @@ class BranchSpecification:
                 continue
             repo = self._repos.repo(branch.name)
             hexsha = repo.commit(branch.branch).hexsha
-            if  branch.sha != hexsha:
+            if branch.sha != hexsha:
                 return branch.name + "=" + repo.git.rev_parse(hexsha, short=True)
         return False
 
@@ -140,6 +143,7 @@ class TimeoutException(Exception):
     def __str__(self):
         return self._msg
 
+
 def is_build_lab():
     buildspec = ProjectMap().build_spec()
     master_host = buildspec.find("build_master").attrib["hostname"]
@@ -154,123 +158,163 @@ def is_build_lab():
         # error from ping: not in build lab
         return False
     return True
-    
-    
+
+
+class RepoNotCloned(Exception):
+    def __init__(self, repo):
+        Exception.__init__(self, "Repo should be cloned first: %s" % repo)
+
+
 class RepoSet:
     """this class represents the set of git repositories which are
     specified in the build_specification.xml file."""
-    def __init__(self, clone=False, cached_only=False):
+    def __init__(self, repos_root=None, use_cache=True, mirror=False):
+        """
+        Keyword arguments:
+        repos_root  -- Destination for git repositories (default is ./repos/)
+        use_cache   -- Cloning/fetching will happen from
+                       build_master (default True)
+        mirror      -- Pass --mirror when creating clones (default False)
+        """
         buildspec = ProjectMap().build_spec()
         self._repos = {}
-        # key is project, value is dictionary of remote name => remote object
+        # key is repo name, value is dictionary of remote name => remote object
         self._remotes = {}
-        # key is project, value is the default branch for the repo (usually master)
+        # key is repo name, value is the default branch for the repo
+        # (usually master)
         self._branches = {}
         if type(buildspec) == str or type(buildspec) == unicode:
             buildspec = et.parse(buildspec)
-        repo_dir = ProjectMap().source_root() + "/repos"
-        repos = buildspec.find("repos")
+        self._build_lab = is_build_lab()
+        self._master_host = buildspec.find("build_master").attrib["hostname"]
+        # systems not in build lab should not use cache (e.g. the system is an
+        # external developer system).
+        self._use_cache = use_cache and self._build_lab
+        self._mirror = mirror
 
-        build_lab = is_build_lab()
-        build_lab_git = "git://" + \
-                        ProjectMap().build_spec().find("build_master").attrib["hostname"] + \
-                        ".local/git/"
-        if os.name == "nt":
-            build_lab_git = "git://" + \
-                            ProjectMap().build_spec().find("build_master").attrib["host"] + \
-                            "/git/"
+        self._repos_root = ProjectMap().source_root() + "/repos/"
+        if repos_root:
+                self._repos_root = repos_root
+
+        if self._use_cache:
+            self._git_cache = ("git://" +
+                               ProjectMap().build_spec().find("build_master").attrib["hostname"] +
+                               ".local/git/")
+
+    def clone(self):
+        """ Clone all repos specified in build_specification.xml
+            Note: This method does *not* fetch remotes """
+        if not os.path.exists(self._repos_root):
+            os.makedirs(self._repos_root)
         attempts = 1
-        if build_lab:
+        if self._build_lab and self._use_cache:
             attempts = 10
-
+        # Parse buildspec in case there were changes since RepoSet
+        # was initialized
         buildspec = ProjectMap().build_spec()
-        master_host = buildspec.find("build_master").attrib["hostname"]
+        if type(buildspec) == str or type(buildspec) == unicode:
+            buildspec = et.parse(buildspec)
 
-        # fetch all the repos into _repo_dir
+        repos = buildspec.find("repos")
+        # clone all the repos into repos_root
         for tag in repos:
-            project = tag.tag
+            repo_name = tag.tag
+            repo_dir = self._repos_root + tag.tag
             repo = None
+            # Builders/testers should clone from master's cache,
+            # everything else will clone from upstream.
             url = tag.attrib["repo"]
-            if build_lab:
-                url = build_lab_git + project + "/origin"
+            if self._use_cache:
+                url = self._git_cache + repo_name
             branch = "origin/master"
-            if tag.attrib.has_key("branch"):
+            if "branch" in tag.attrib:
                 branch = tag.attrib["branch"]
-            if cached_only and master_host not in url:
-                print("Skipping non-cached remote")
-                continue
-
-            # prohibit double entry
-            assert not self._repos.has_key(project)
-            project_repo_dir = repo_dir + "/" + project
- 
-            if os.path.exists(project_repo_dir + "/do_not_use"):
-                continue
-
-            if os.path.exists(project_repo_dir):
+            # Try to use existing repo_dir if there is one. If it's invalid
+            # and not explicitly disabled, then remove it so that a re-clone
+            # can be attempted
+            if os.path.exists(repo_dir) and not os.path.exists(repo_dir +
+                                                               "/do_not_use"):
                 try:
-                    repo = git.Repo(project_repo_dir)
+                    repo = git.Repo(repo_dir)
                 except git.InvalidGitRepositoryError:
                     # Something broke with the repo, so remove it and re-clone
-                    print("INFO: Repo path is not a valid git repo: %s. "
-                          "Attempting to repair... " % project_repo_dir)
-                    shutil.rmtree(project_repo_dir)
-                    clone = True
-
-            if not os.path.exists(project_repo_dir) and clone:
-                os.makedirs(project_repo_dir)
+                    print("INFO: Repo path exists but is not a valid git "
+                          "repo: %s. Attempting to repair... " % repo_dir)
+                    shutil.rmtree(repo_dir)
+            # Clone any repos that do not exist on disk
+            if not os.path.exists(repo_dir):
                 success = False
-                for attempt in range(0,attempts):
+                for attempt in range(0, attempts):
                     if attempt > 0:
                         time.sleep(10)
                     try:
-                        print "attempting clone of " + url
-                        git.Repo.clone_from(url,
-                                            project_repo_dir)
+                        print("Attempting clone of %s" % url)
+                        git.Repo.clone_from(url, repo_dir,
+                                            mirror=self._mirror)
                         success = True
                         break
                     except:
-                        print "WARN: unable to clone repo: " + url
-                if not success and not build_lab:
-                    os.makedirs(project_repo_dir + "/do_not_use")
+                        print("WARN: unable to clone repo: %s\n"
+                              "Exception text: %s" % (url, sys.exc_info()[0]))
+                # If the repo is not clone-able, do_not_use is used to disable
+                # it from any future attempts to clone/fetch
+                if not success and not self._build_lab:
+                    os.makedirs(repo_dir + "/do_not_use")
                     continue
+            if os.path.exists(repo_dir + "/do_not_use"):
+                continue
+            try:
+                repo = git.Repo(repo_dir)
+            except git.InvalidGitRepositoryError:
+                if not self._build_lab:
+                    os.makedirs(repo_dir + "/do_not_use")
+                print("WARNING: Unable to clone repo: %s" % repo_name)
+            # Systems not using cache (e.g. cloning from an external remote
+            # should add all remotes to the repo.
+            if not self._use_cache:
+                for a_remote in tag.findall("remote"):
+                    remote_name = a_remote.attrib["name"]
+                    remote_repo = a_remote.attrib["repo"]
+                    if not remote_name or not remote_repo:
+                        continue
+                    remote = None
+                    try:
+                        remote = repo.remote(name=remote_name)
+                        # Remote does not exist, so add it
+                        # Note: remotes are added to the repo with the
+                        # following fetch refspec:
+                        #    +refs/heads/*:refs/<remote_name>/*
+                    except ValueError:
+                        remote = repo.create_remote(remote_name, remote_repo)
+                        with remote.config_writer as c:
+                            c.config.set_value('remote \"' + remote_name
+                                               + '\"', 'fetch',
+                                               '+refs/heads/*:refs/'
+                                               + remote_name + '/*')
+            else:
+                # For systems that will be fetching from build master's git
+                # cache, add the appropriate fetch refspec so that refs are
+                # mapped to refs/remotes/*
+                origin = repo.remote("origin")
+                assert origin is not None
+                with origin.config_writer as c:
+                    c.set('fetch', '+refs/*:refs/remotes/*')
 
-            if not repo:
-                try:
-                    repo = git.Repo(project_repo_dir)
-                except git.InvalidGitRepositoryError:
-                    raise SystemError("FATAL: Unable to create repo: %s" % project_repo_dir)
-
-            self._repos[project] = repo
-            self._remotes[project] = {}
-            self._branches[project] = branch
-
+            # Store repo, branch, and remote object(s)
+            self._repos[repo_name] = repo
+            self._branches[repo_name] = branch
+            self._remotes[repo_name] = {}
+            tag_remotes = [x.attrib["name"] for x in tag.findall("remote")]
             for remote in repo.remotes:
-                self._remotes[project][remote.name] = remote
-
-            for a_remote in tag.findall("remote"):
-                remote_name = a_remote.attrib["name"]
-                if not self._remotes[project].has_key(remote_name) and clone:
-                    url = a_remote.attrib["repo"]
-                    if build_lab:
-                        url = build_lab_git + project + "/" + remote_name
-                    for attempt in range(0,attempts):
-                        print "Adding remote: " + remote_name + " " + url
-                        success = False
-                        try:
-                            if attempt > 0:
-                                time.sleep(10)
-                            remote = repo.create_remote(remote_name, url)
-                            remote.fetch()
-                            success = True
-                            self._remotes[project][remote_name] = remote
-                            break
-                        except:
-                            print "WARN: remote not available: " + url
-                            repo.delete_remote(remote_name)
-                    if not success and not build_lab:
-                        # make a dummy remote, so it doesn't attempt to fetch later
-                        remote = repo.create_remote(remote_name, project_repo_dir)
+                self._remotes[repo_name][remote.name] = remote
+                # Clean out any remotes that are no longer in the buildspec
+                if remote.name == "origin":
+                    continue
+                if remote.name not in tag_remotes:
+                    print("Remote does not exist in buildspec anymore, "
+                          "deleting it: %s"
+                          % remote.name)
+                    repo.delete_remote(remote.name)
 
     def repo(self, project_name):
         return self._repos[project_name]
@@ -285,33 +329,41 @@ class RepoSet:
         if os.name != "nt":
             signal.alarm(secs)   # 5 minutes
 
-    def fetch(self, cached_only=False):
+    def fetch(self):
         def signal_handler(signum, frame):
             raise TimeoutException("Fetch timed out.")
 
         buildspec = ProjectMap().build_spec()
-        master_host = buildspec.find("build_master").attrib["hostname"]
-
-        for repo in self._repos.values():
-            garbage_collection_fail = repo.working_tree_dir + "/.git/gc.log"
-            if os.path.exists(garbage_collection_fail):
-                run_batch_command(["rm", "-f", garbage_collection_fail])
+        self._master_host = buildspec.find("build_master").attrib["hostname"]
+        buildspec_repos = buildspec.find("repos")
+        for tag in buildspec_repos:
+            repo_name = tag.tag
+            # Make sure the repo we're fetching has been cloned first:
+            if repo_name not in self._repos.keys():
+                raise RepoNotCloned(repo_name)
+            repo = self._repos[repo_name]
+            # Removing gc.log is relevant only for systems where the repo
+            # is not bare:
+            if repo.working_tree_dir:
+                garbage_collection_fail = (repo.working_tree_dir +
+                                           "/.git/gc.log")
+                if os.path.exists(garbage_collection_fail):
+                    run_batch_command(["rm", "-f", garbage_collection_fail])
             try:
                 repo.git.prune()
             except Exception as e:
-                print "ERROR: git repo is corrupt, removing: " + repo.working_tree_dir
+                print("ERROR: git repo is corrupt, removing: %s" %
+                      repo.working_tree_dir)
                 run_batch_command(["rm", "-rf", repo.working_tree_dir])
-                raise;
+                raise
             if os.name != "nt":
                 signal.signal(signal.SIGALRM, signal_handler)
+            # Iterate through all remotes and fetch them
             for remote in repo.remotes:
-                if cached_only and master_host not in remote.url:
-                    print("Skipping non-cached remote")
-                    continue
                 print "fetching " + remote.url
                 # 4 attempts
                 success = False
-                for _ in range(1,4):
+                for _ in range(1, 4):
                     try:
                         self.alarm(300)   # 5 minutes
                         remote.fetch()
@@ -319,23 +371,18 @@ class RepoSet:
                         success = True
                         break
                     except git.GitCommandError as e:
-                        print "error fetching: " + str(e)
-                        self.alarm(0)
-                        time.sleep(1)
+                        print("error fetching: %s" % str(e))
                     except AssertionError as e:
-                        print "assertion while fetching: " + str(e)
-                        self.alarm(0)
-                        time.sleep(1)
+                        print("assertion while fetching: %s" % str(e))
                     except TimeoutException as e:
-                        print str(e)
+                        print(str(e))
                     except Exception as e:
-                        print str(e)
+                        print(str(e))
+                    finally:
+                        self.alarm(0)
                         time.sleep(1)
                 if not success:
-                    print "Failed to fetch remote, ignoring: " + remote.url
-        # the fetch has left our repo objects in an inconsistent
-        # state.  We need to recreate them.
-        self.__init__()
+                    print("Failed to fetch remote, ignoring: %s" % remote)
 
     def branch_missing_revisions(self):
         """provides the revisions which are on master but are not on the
@@ -446,22 +493,24 @@ class RevisionSpecification:
         return self._revisions[project]
 
 class RepoStatus:
-    def __init__(self, buildspec=None, cached_only=False):
+    def __init__(self, buildspec=None, repos_root=None):
         if not buildspec:
             buildspec = ProjectMap().build_spec()
         if type(buildspec) == str or type(buildspec) == unicode:
             buildspec = et.parse(buildspec)
 
-        self._cached_only = cached_only
-
         # key is project, value is repo object
-        self._repos = RepoSet(cached_only=self._cached_only)
+        self._repos = RepoSet(repos_root=repos_root)
 
         # referencing the HEAD of an unfetched remote will fail.  This
         # happens the first time branches are polled
         # after. build_specification.xml has been updated to add a
         # remote.
-        self._repos.fetch(self._cached_only)
+        try:
+            self._repos.fetch()
+        except RepoNotCloned:
+            self._repos.clone()
+            sefl._repos.fetch()
 
         self._branches = []
 
@@ -478,7 +527,11 @@ class RepoStatus:
     def poll(self):
         """returns list of branches that should be triggered"""
         ret_dict = {}
-        self._repos.fetch(self._cached_only)
+        try:
+            self._repos.fetch()
+        except RepoNotCloned:
+            self._repos.clone()
+            self._repos.fetch()
         for branch in self._branches:
             trigger_commit = branch.needs_build()
             if trigger_commit:
@@ -493,7 +546,6 @@ class BuildSpecification:
         if type(buildspec) == str or type(buildspec) == unicode:
             buildspec = et.parse(buildspec)
 
-        self._buildspec = buildspec
         self._reposet = RepoSet()
         self._branch_specs = {}
 

--- a/services/fetch_mirrors/fetch_mirrors.py
+++ b/services/fetch_mirrors/fetch_mirrors.py
@@ -1,81 +1,29 @@
 #!/usr/bin/python2
 
 from __future__ import print_function
-import hashlib
 import os
 import signal
-import subprocess
 import sys
 import time
 
-import git
-import socket
-if socket.gethostname() == "otc-mesa-ci":
-    sys.path.append("/var/lib/git/mesa_jenkins/services/")
-elif socket.gethostname() == "otc-mesa-android":
-    sys.path.append("/var/lib/git/mesa_perf/repos/mesa_ci/services/")
+sys.path.append("/var/cache/mesa_jenkins/services/")
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])), ".."))
+import util
 
-sys.path.append("/var/lib/git/mesa_jenkins/")
+sys.path.append("/var/cache/mesa_jenkins/")
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])), "../.."))
 import build_support as bs
 
 sys.argv[0] = os.path.abspath(sys.argv[0])
 
-class TimeoutException(Exception):
-    def __init__(self, msg):
-        Exception.__init__(self)
-        self._msg = msg
-
-    def __str__(self):
-        return self._msg
-
-
-def signal_handler(signum, frame):
-    raise TimeoutException("Fetch timed out.")
-
-
-def signal_handler_quit(signum, frame):
-    sys.exit(-1)
-
-
-def robust_clone(url, directory):
-    success = False
-    while not success:
-        try:
-            bs.run_batch_command(["/usr/local/bin/git", "clone", "--mirror",
-                                  url, directory])
-            success = True
-        except(subprocess.CalledProcessError):
-            print("Error: could not clone " + url, file=sys.stderr)
-            time.sleep(10)
-
-
-def robust_update():
-    _success = False
-    while not _success:
-        try:
-            _repo = git.Repo(bs.ProjectMap().source_root())
-            _repo.remotes.origin.pull()
-            _success = True
-        except:
-            print("Error: could not update buildsupport", file=sys.stderr)
-            time.sleep(10)
-            
-
-def file_checksum(fname):
-    with open(fname, 'rb') as f:
-        return hashlib.md5(f.read()).digest()
-
 
 def main():
     # Write the PID file
-    with open('/var/run/fetch_mesa_mirrors.pid', 'w') as f:
-        f.write(str(os.getpid()))
+    util.write_pid('/var/run/fetch_mesa_mirrors.pid')
 
-    signal.signal(signal.SIGALRM, signal_handler)
-    signal.signal(signal.SIGINT, signal_handler_quit)
-    signal.signal(signal.SIGTERM, signal_handler_quit)
+    signal.signal(signal.SIGALRM, util.signal_handler)
+    signal.signal(signal.SIGINT, util.signal_handler_quit)
+    signal.signal(signal.SIGTERM, util.signal_handler_quit)
 
     # running a service through intel's proxy requires some
     # annoying settings.
@@ -83,68 +31,32 @@ def main():
     # without this, git-remote-https spins at 100%
     os.environ["http_proxy"] = "http://proxy.jf.intel.com:911/"
     os.environ["https_proxy"] = "http://proxy.jf.intel.com:911/"
+    cache_location = os.environ.get("FETCH_MIRRORS_CACHE_DIR")
+    if not cache_location:
+        cache_location = "/var/lib/git/"
 
     try:
         bs.ProjectMap()
     except:
-        sys.argv[0] = "/var/lib/git/mesa_jenkins/foo.py"
-        if socket.gethostname() == "otc-mesa-android":
-            sys.argv[0] = "/var/lib/git/mesa_perf/foo.py"
+        sys.argv[0] = "/var/cache/mesa_jenkins/foo.py"
 
-    robust_update()
-
-    pm = bs.ProjectMap()
-    spec_file = pm.source_root() + "/build_specification.xml"
-    new_spec_hash = None
+    if not os.path.exists(cache_location):
+        os.makedirs(cache_location)
+    # This *is* the service that creates the git cache, so do not use a cache
+    # and create repos that are git clone mirrors:
+    repos = bs.RepoSet(repos_root=cache_location, use_cache=False, mirror=True)
+    repos.clone()
 
     while True:
-        orig_spec_hash = file_checksum(spec_file)
-        if new_spec_hash is not None:
-            print("Build Specification updated")
-        new_spec_hash = file_checksum(spec_file)
-
-        while new_spec_hash == orig_spec_hash:
-            buildspec = bs.ProjectMap().build_spec()
-
-            repo_dir = "/var/lib/git/"
-
-            # build up a list of git repo objects for all known repos.  If the
-            # origin or the remotes are not already cloned, clone them.
-            repos = []
-            repo_tags = buildspec.find("repos")
-            for tag in repo_tags:
-                url = tag.attrib["repo"]
-                project = tag.tag
-                origin_dir = repo_dir + project + "/origin"
-                if not os.path.exists(origin_dir):
-                    robust_clone(url, origin_dir)
-                    bs.run_batch_command(["touch", origin_dir + "/git-daemon-export-ok"])
-                repos.append(git.Repo(origin_dir))
-                for a_remote in tag.findall("remote"):
-                    remote_dir = repo_dir + project + "/" + a_remote.attrib["name"]
-                    if not os.path.exists(remote_dir):
-                        robust_clone(a_remote.attrib["repo"], remote_dir)
-                        bs.run_batch_command(["touch", remote_dir + "/git-daemon-export-ok"])
-                    repos.append(git.Repo(remote_dir))
-
-            for repo in repos:
-                try:
-                    signal.alarm(300)   # 5 minutes
-                    repo.git.fetch()
-                    signal.alarm(0)
-                except git.GitCommandError as e:
-                    print("error fetching, ignoring: " + str(e), file=sys.stderr)
-                    signal.alarm(0)
-                except AssertionError as e:
-                    print("assertion while fetching: " + str(e), file=sys.stderr)
-                    signal.alarm(0)
-                except TimeoutException as e:
-                    print (str(e), file=sys.stderr)
-                    signal.alarm(0)
+        try:
+            signal.alarm(300)   # 5 minutes
+            repos.fetch()
+        except bs.repo_set.RepoNotCloned:
+            repos.clone()
+        finally:
+            signal.alarm(0)
             # pause a bit before fetching the next round
-            time.sleep(20)
-            robust_update()
-            new_spec_hash = file_checksum(spec_file)
+        time.sleep(20)
 
 
 if __name__ == "__main__":

--- a/services/fetch_mirrors/fetch_mirrors.service
+++ b/services/fetch_mirrors/fetch_mirrors.service
@@ -6,7 +6,8 @@ Wants=network-online.target
 [Service]
 Type=simple
 PIDFile=/var/run/fetch_mirrors.pid
-ExecStart=/var/lib/git/mesa_jenkins/services/fetch_mirrors/fetch_mirrors.py
+Environment=FETCH_MIRRORS_CACHE_DIR=/var/lib/git/
+ExecStart=/var/cache/mesa_jenkins/services/fetch_mirrors/fetch_mirrors.py
 Restart=on-failure
 
 [Install]

--- a/services/mesa_jenkins_monitor/mesa_jenkins_monitor.py
+++ b/services/mesa_jenkins_monitor/mesa_jenkins_monitor.py
@@ -1,0 +1,144 @@
+#!/usr/bin/python2
+
+# Copyright (C) Intel Corp.  2017.  All Rights Reserved.
+
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+
+# The above copyright notice and this permission notice (including the
+# next paragraph) shall be included in all copies or substantial
+# portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE COPYRIGHT OWNER(S) AND/OR ITS SUPPLIERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#  **********************************************************************/
+#  * Authors:
+#  *   Clayton Craft <clayton.a.craft@intel.com>
+#  **********************************************************************/
+
+"""
+Notes:
+    - monitors the following files and restarts poll_branches and fetch_mirrors
+      services on any changes:
+        - services/fetch_mirrors/fetch_mirrors.py
+        - services/poll_branches/poll_branches.py
+        - build_specification.xml
+    - updates mesa_jenkins workspace (/var/cache/mesa_jenkins
+
+"""
+import git
+import os
+import subprocess
+import sys
+import time
+
+sys.path.append("/var/cache/mesa_jenkins/services/")
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])), ".."))
+import util
+
+sys.path.append("/var/cache/mesa_jenkins/")
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])), "../.."))
+import build_support as bs
+
+# Branch to use for mesa_jenkins working directory
+BRANCH = "master"
+
+
+class ServiceRestartFailure(Exception):
+    def __init__(self, service_name, stdout, stderr):
+        self.name = service_name
+        self.stdout = stdout
+        self.stderr = stderr
+
+    def __str__(self):
+        return ("FATAL: Unable to restart service %s:\n"
+                "Output from failing command: %s\n%s"
+                % (self.name, self.stdout, self.stderr))
+
+
+def restart_service(service_name):
+    # Restart service
+    p = subprocess.Popen(["systemctl", "restart", service_name],
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE)
+    out, err = p.communicate()
+    if p.returncode:
+        raise ServiceRestartFailure(service_name, out, err)
+
+
+def reload_service_files():
+    # Call daemon-reload in case systemd .service file was changed
+    subprocess.cehck_call(["systemctl", "daemon-reload"],
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE)
+
+
+def main():
+
+    util.write_pid('/var/run/mesa_jenkins_monitor.pid')
+    try:
+        bs.ProjectMap()
+    except:
+        sys.argv[0] = "/var/cache/mesa_jenkins/foo.py"
+    pm = bs.ProjectMap()
+
+    # Locations of files that trigger service restarts:
+    spec_file = os.path.join(pm.source_root(), "build_specification.xml")
+    poll_branches_file = os.path.join(pm.source_root(),
+                                      "services/poll_branches"
+                                      "/poll_branches.py")
+    fetch_mirrors_file = os.path.join(pm.source_root(),
+                                      "services/fetch_mirrors/"
+                                      "fetch_mirrors.py")
+    new_spec_hash = None
+    new_poll_branches_hash = None
+    new_fetch_mirrors_hash = None
+
+    mesa_jenkins_repo = git.Repo(pm.source_root())
+    while True:
+        spec_hash = util.file_checksum(spec_file)
+        poll_branches_hash = util.file_checksum(poll_branches_file)
+        fetch_mirrors_hash = util.file_checksum(fetch_mirrors_file)
+        try:
+            mesa_jenkins_repo.git.pull("origin", BRANCH)
+            mesa_jenkins_repo.git.checkout(BRANCH, force=True)
+        except git.GitCommandError:
+            raise Exception("FATAL: Unable to update mesa_jenkins "
+                            "work directory: %s" % pm.source_root())
+
+        new_spec_hash = util.file_checksum(spec_file)
+        new_poll_branches_hash = util.file_checksum(poll_branches_file)
+        new_fetch_mirrors_hash = util.file_checksum(fetch_mirrors_file)
+
+        # Reload service files and restart services if any interesting files
+        # have changed
+        if (new_spec_hash != spec_hash or
+                new_poll_branches_hash != poll_branches_hash or
+                new_fetch_mirrors_hash != fetch_mirrors_hash):
+
+            print("INFO: Change detected in service files and/or build_spec, "
+                  "restarting services!")
+            spec_hash = new_spec_hash
+            poll_branches_hash = new_poll_branches_hash
+            fetch_mirrors_hash = new_fetch_mirrors_hash
+
+            reload_service_files()
+            restart_service("fetch_mirrors")
+            restart_service("poll_branches")
+        time.sleep(30)
+    return
+
+
+if __name__ == "__main__":
+    main()

--- a/services/mesa_jenkins_monitor/mesa_jenkins_monitor.service
+++ b/services/mesa_jenkins_monitor/mesa_jenkins_monitor.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Monitor for mesa_jenkins work directory
+
+[Service]
+Type=simple
+PIDFile=/var/run/mesa_jenkins_monitor.pid
+ExecStart=/var/cache/mesa_jenkins/services/mesa_jenkins_monitor/mesa_jenkins_monitor.py
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/services/poll_branches/poll_branches.py
+++ b/services/poll_branches/poll_branches.py
@@ -20,6 +20,7 @@ import urllib2
 # checkout, and not when runnning as a service.
 sys.path.append("/var/lib/git/mesa_jenkins/services/")
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])), ".."))
+import util
 
 # append build_support directory to pythonpath, so we can make use of
 # RepoSet etc.  Second line is for finding build_support when running
@@ -35,66 +36,50 @@ os.environ["http_proxy"] = "http://proxy.jf.intel.com:911/"
 os.environ["https_proxy"] = "http://proxy.jf.intel.com:911/"
 
 
-def write_pid(pidfile):
-    """Write the PID file."""
-    with open(pidfile, 'w') as f:
-        f.write(str(os.getpid()))
-
-
-def file_checksum(fname):
-    return hashlib.md5(open(fname, 'rb').read()).digest()
-
-
 def main():
-    write_pid('/var/run/poll_branches.pid')
+    util.write_pid('/var/run/poll_branches.pid')
     try:
         bs.ProjectMap()
     except:
-        sys.argv[0] = "/var/lib/git/mesa_jenkins/foo.py"
+        sys.argv[0] = "/var/cache/mesa_jenkins/foo.py"
     pm = bs.ProjectMap()
-    spec_file = pm.source_root() + "/build_specification.xml"
+    spec = pm.build_spec()
+    server = spec.find("build_master").attrib["host"]
 
-    new_spec_hash = None
     while True:
-        orig_spec_hash = file_checksum(spec_file)
-        spec = pm.build_spec()
-        server = spec.find("build_master").attrib["host"]
-        if new_spec_hash is not None:
-            print("Build Specification updated", file=sys.stderr)
+        status = bs.RepoStatus()
+        branches = status.poll()
+        sys.stderr.flush()
+        sys.stdout.flush()
+        for (branch, commit) in branches.iteritems():
+            print("Building " + branch, file=sys.stderr)
             sys.stderr.flush()
-        new_spec_hash = file_checksum(spec_file)
-        status = bs.RepoStatus(cached_only=True)
-        while new_spec_hash == orig_spec_hash:
-            branches = status.poll()
-            sys.stderr.flush()
-            sys.stdout.flush()
-            for (branch, commit) in branches.iteritems():
-                print("Building " + branch, file=sys.stderr)
-                sys.stderr.flush()
-                job_url = "http://" + server + "/job/" + branch + \
-                          "/buildWithParameters?token=noauth&name=" + commit + "&type=percheckin"
-                retry_count = 0
+            job_url = ("http://" + server + "/job/" + branch +
+                       "/buildWithParameters?token=noauth&name=" + commit +
+                       "&type=percheckin")
+            retry_count = 0
 
-                # how wonderful, the proxy setting is required for
-                # git but prevents the service from accessing
-                # otc-mesa-ci.
-                os.environ["http_proxy"] = ""
-                while retry_count < 10:
-                    try:
-                        f = urllib2.urlopen(job_url)
-                        f.read()
-                        break
-                    except urllib2.HTTPError as e:
-                        print(e, file=sys.stderr)
-                        retry_count = retry_count + 1
-                        print("ERROR: failed to reach jenkins, retrying: " + job_url,
-                              file=sys.stderr)
-                        sys.stderr.flush()
-                        time.sleep(10)
-                os.environ["http_proxy"] = "http://proxy.jf.intel.com:911/"
+            # how wonderful, the proxy setting is required for
+            # git but prevents the service from accessing
+            # otc-mesa-ci.
+            os.environ["http_proxy"] = ""
+            while retry_count < 10:
+                try:
+                    f = urllib2.urlopen(job_url)
+                    f.read()
+                    f.close()
+                    break
+                except urllib2.HTTPError as e:
+                    print(e, file=sys.stderr)
+                    retry_count = retry_count + 1
+                    print("ERROR: failed to reach jenkins, retrying: " +
+                          job_url, file=sys.stderr)
+                    sys.stderr.flush()
+                    time.sleep(10)
+            os.environ["http_proxy"] = "http://proxy.jf.intel.com:911/"
 
-            time.sleep(30)
-            new_spec_hash = file_checksum(spec_file)
+        time.sleep(30)
+
 
 if __name__ == "__main__":
     main()

--- a/services/poll_branches/poll_branches.service
+++ b/services/poll_branches/poll_branches.service
@@ -4,7 +4,7 @@ Description=Poll git branches and start new Jenkins jobs
 [Service]
 Type=simple
 PIDFile=/var/run/poll_branches.pid
-ExecStart=/var/lib/git/mesa_jenkins/services/poll_branches/poll_branches.py
+ExecStart=/var/cache/mesa_jenkins/services/poll_branches/poll_branches.py
 Restart=on-failure
 
 [Install]

--- a/services/util/__init__.py
+++ b/services/util/__init__.py
@@ -1,0 +1,1 @@
+from util import *

--- a/services/util/util.py
+++ b/services/util/util.py
@@ -1,0 +1,62 @@
+# Copyright (C) Intel Corp.  2017.  All Rights Reserved.
+
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+
+# The above copyright notice and this permission notice (including the
+# next paragraph) shall be included in all copies or substantial
+# portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE COPYRIGHT OWNER(S) AND/OR ITS SUPPLIERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#  **********************************************************************/
+#  * Authors:
+#  *   Mark Janes <mark.a.janes@intel.com>
+#  *   Clayton Craft <clayton.a.craft@intel.com>
+#  **********************************************************************/
+
+# util.py - Collection of useful methods for mesa_jenkins services
+
+import hashlib
+import os
+import sys
+
+
+def write_pid(pidfile):
+    """Write the PID file."""
+    with open(pidfile, 'w') as f:
+        f.write(str(os.getpid()))
+
+
+class TimeoutException(Exception):
+    def __init__(self, msg):
+        Exception.__init__(self)
+        self._msg = msg
+
+    def __str__(self):
+        return self._msg
+
+
+def signal_handler(signum, frame):
+    raise TimeoutException("Fetch timed out.")
+
+
+def signal_handler_quit(signum, frame):
+    sys.exit(-1)
+
+
+def file_checksum(fname):
+    """ Generate md5 checksum for given file """
+    with open(fname, 'rb') as f:
+        return hashlib.md5(f.read()).digest()


### PR DESCRIPTION
This converts the caching structure to a 'flat' model, where remotes are cached
in a single repo for each project. As a result, the poll_branches and
fetch_mirrors services have been adjusted to handle this new structure.

A new service, mesa_jenkins_monitor, was created to manage the poll_branches &
fetch_mirrors services (e.g. restarting them if they were updated or if
build_spec has been changed).

undo accidental commenting of code

Clean up & implement requested changes

fix typo in building git_cache url