### PR TITLE
mesa_jenkins_monitor: add checkout of repos/mesa_ci

### DIFF
--- a/services/mesa_jenkins_monitor/mesa_jenkins_monitor.py
+++ b/services/mesa_jenkins_monitor/mesa_jenkins_monitor.py
@@ -106,6 +106,8 @@ def main():
     new_fetch_mirrors_hash = None
 
     mesa_jenkins_repo = git.Repo(pm.source_root())
+    mesa_ci_repo = git.Repo(os.path.join(pm.source_root(),
+                                         "repos/mesa_ci"))
     while True:
         spec_hash = util.file_checksum(spec_file)
         if os.path.exists(poll_branches_file):
@@ -115,6 +117,7 @@ def main():
         try:
             mesa_jenkins_repo.git.pull("origin", BRANCH)
             mesa_jenkins_repo.git.checkout(BRANCH, force=True)
+            mesa_ci_repo.checkout(BRANCH, force=True)
         except git.GitCommandError:
             raise Exception("FATAL: Unable to update mesa_jenkins "
                             "work directory: %s" % pm.source_root())


### PR DESCRIPTION
This allows poll_branches and fetch_mirrors sources to be updated in the work tree