### PR TITLE
perf_builder: use appropriate python interpreter on Windows for sixonix

### DIFF
--- a/build_support/perf_builder.py
+++ b/build_support/perf_builder.py
@@ -95,7 +95,7 @@ class PerfBuilder(object):
             interpreter = sys.executable
             # sixonix requires python3
             if not sys.version.startswith("3"):
-                interpreter = "python3"
+                interpreter = "py -3" if os.name == "nt" else "python3"
             cmd = [interpreter, "sixonix.py", "run"]
             if not self._windowed:
                 cmd += ["--fullscreen"]


### PR DESCRIPTION
Since both Python 2 and Python 3 provide 'python.exe', this calls the py 'wrapper' to explicitly choose python3 when running sixonix