### PR TITLE
Make watcher smarter

### DIFF
--- a/services/reboot_hung_systems/reboot_hung_systems-watcher.path
+++ b/services/reboot_hung_systems/reboot_hung_systems-watcher.path
@@ -1,0 +1,5 @@
+[Path]
+PathModified=/var/cache/mesa_jenkins/reboot_hung_systems_config.json
+
+[Install]
+WantedBy=multi-user.target

--- a/services/reboot_hung_systems/reboot_hung_systems-watcher.service
+++ b/services/reboot_hung_systems/reboot_hung_systems-watcher.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Hung System restart watcher
+After=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/systemctl restart reboot_hung_systems

--- a/services/reboot_hung_systems/reboot_hung_systems.service
+++ b/services/reboot_hung_systems/reboot_hung_systems.service
@@ -3,7 +3,7 @@ Description=Control managed switches to reboot hung systems
 
 [Service]
 Type=simple
-ExecStart=/var/cache/mesa_jenkins/repos/mesa_ci/services/reboot_hung_systems/reboot_hung_systems.service
+ExecStart=/var/cache/mesa_jenkins/repos/mesa_ci/services/reboot_hung_systems/reboot_hung_systems.py
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
This has two patches, one that fixes the reboot hung systems systemd unit to actually work, and one that allows systemd to monitor the .json file and restart the reboot hung systems service whenever it changes. Both have been tested.

I'll send a corresponding salt change to symlink the watchers.