### PR TITLE
update_conf: strip trailing whitespace from blame revision

### DIFF
--- a/scripts/update_conf.py
+++ b/scripts/update_conf.py
@@ -40,7 +40,7 @@ for a_rev in revs:
     rev = a_rev.split("=")[1]
     rev_hash[proj] = rev
 
-blame = args.blame_revision.split("=")
+blame = args.blame_revision.rstrip().split("=")
 if len(blame) != 2:
     print "ERROR: --blame_revision must be in the format: project=rev"
     sys.exit(-1)


### PR DESCRIPTION
git python cannot handle trailing whitespaces, which are preserved after the
split('=') and passed as a part of the sha to gitpython


I wasn't able to test this in CI since we don't have a way to specify custom mesa_ci branches for the 'accept failured tests' build. This is meant to prevent this failure: http://otc-mesa-ci.jf.intel.com/job/accept_failed_tests/1117/console