### PR TITLE
monitor service: failure to restart services is not fatal

### DIFF
--- a/services/mesa_jenkins_monitor/mesa_jenkins_monitor.py
+++ b/services/mesa_jenkins_monitor/mesa_jenkins_monitor.py
@@ -74,7 +74,10 @@ def restart_service(service_name):
                          stderr=subprocess.PIPE)
     out, err = p.communicate()
     if p.returncode:
-        raise ServiceRestartFailure(service_name, out, err)
+        # This is not fatal, since this may be running in a CI
+        # without poll_branches
+        print("WARN: Unable to start service: %s. Maybe it doesn't exist? "
+              "Output: %s %s\nContinuing..." % (service_name, out, err))
 
 
 def reload_service_files():


### PR DESCRIPTION
Some CI systems (e.g. perf CI) may not have all services installed (e.g.
poll_branches), so the monitor service should continue when there is a failure.

This prints a warning to stdout when a service fails to start so that legit
failures can still be debugged.